### PR TITLE
enable building gcc with openmp using winpthreads

### DIFF
--- a/mingw-w64+gcc.sh
+++ b/mingw-w64+gcc.sh
@@ -19,12 +19,28 @@ mv mingw-w64-v5.0.2 src
 mkdir build dest
 cd build
 
+#configure winpthread
+../src/mingw-w64-libraries/winpthreads/configure \
+    --prefix=/c/temp/gcc/dest/x86_64-w64-mingw32 \
+	--target=x86_64-w64-mingw32 \
+    --host=x86_64-w64-mingw32 \
+	--with-sysroot=/c/temp/gcc/dest/x86_64-w64-mingw32 \
+|| fail_with winpthread 1 - EPIC FAIL
+
+#build winpthread
+make all "CFLAGS=-s -O3" || fail_with winpthread 2 - EPIC FAIL
+
+#configure mingw
 ../src/configure --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --disable-lib32 \
 --prefix=/c/temp/gcc/dest/x86_64-w64-mingw32 --with-sysroot=/c/temp/gcc/dest/x86_64-w64-mingw32 --enable-wildcard \
 || fail_with mingw-w64 1 - EPIC FAIL
 
+#build mingw
 make $X_MAKE_JOBS all "CFLAGS=-s -O3" || fail_with mingw-w64 2 - EPIC FAIL
 make install || fail_with mingw-w64 3 - EPIC FAIL
+#before we clean up copy winpthread accross
+cp libpthread.a /c/temp/gcc/dest/x86_64-w64-mingw32/lib
+cp -f ../src/mingw-w64-libraries/winpthreads/include/*.h /c/temp/gcc/dest/x86_64-w64-mingw32/include
 cd /c/temp/gcc
 rm -rf build src
 
@@ -48,6 +64,8 @@ cd build
 ../src/configure --enable-languages=c,c++ --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 \
 --target=x86_64-w64-mingw32 --disable-multilib --prefix=/c/temp/gcc/dest --with-sysroot=/c/temp/gcc/dest \
 --disable-libstdcxx-pch --disable-libstdcxx-verbose --disable-nls --disable-shared --disable-win32-registry \
+--enable-libatomic --enable-threads=posix \
+--enable-lto --enable-libgomp \
 --with-tune=haswell || fail_with gcc 1 - EPIC FAIL
 
 # --enable-languages=c,c++        : I want C and C++ only.

--- a/mingw-w64+gcc.sh
+++ b/mingw-w64+gcc.sh
@@ -64,8 +64,7 @@ cd build
 ../src/configure --enable-languages=c,c++ --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 \
 --target=x86_64-w64-mingw32 --disable-multilib --prefix=/c/temp/gcc/dest --with-sysroot=/c/temp/gcc/dest \
 --disable-libstdcxx-pch --disable-libstdcxx-verbose --disable-nls --disable-shared --disable-win32-registry \
---enable-libatomic --enable-threads=posix \
---enable-lto --enable-libgomp \
+--enable-threads=posix --enable-libgomp \
 --with-tune=haswell || fail_with gcc 1 - EPIC FAIL
 
 # --enable-languages=c,c++        : I want C and C++ only.


### PR DESCRIPTION
This is kind of a hack to the script as the configure of mingw should really do this for us. I haven't tested the other threading parts, only the openmp hello world.