### PR TITLE
C:\MinGW requirement added in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ $ pacman -Syuu
 
 ### Important Notes
 
-The build scripts assume that they can use `C:\Temp\gcc` as a working directory and that they do not live directly within it.
-They also assume that they live next to the sources. I generally put both of them into `C:\Temp\gcc\sources-VERSION` .
+The build scripts assume that some (e.g. previous) version of the toolchain is present in `C:\MinGW`.
+They also assume that they can use `C:\Temp\gcc` as a working directory and that they do not live directly within it.
+And that they live next to the sources. I generally put both of them into `C:\Temp\gcc\sources-VERSION`.
 
 I **highly** recommend that you execute each build script **by hand** before attempting to run it in one shot.
 


### PR DESCRIPTION
I've stumbled upon problems with running the scripts because on a "clean system" the c compiler was not found. Installing it within msys2 with "pacman -Su gcc" wasn't the right solution and perhaps neither was an installing "pacman -Su mingw-w64-x86_64-toolchain" as I've noticed only later in "0_append_distro_path.sh" that it expects some version of "nuwen-mingw" already present in "C:\MinGW"! Well, that might be kinda expected but perhaps would be better stated openly.